### PR TITLE
Qumomf supports multiple clusters

### DIFF
--- a/example/qumomf.yaml
+++ b/example/qumomf.yaml
@@ -1,49 +1,44 @@
 qumomf:
-    port: ':1488'
+  port: ':1488'
 
 tarantool:
-    connect_timeout: '1s'
-    request_timeout: '1s'
+  connect_timeout: '1s'
+  request_timeout: '1s'
 
-shards:
-    7432f072-c00b-4498-b1a6-6d9547a8a150:
+  topology:
+    user: 'qumomf'
+    password: 'qumomf'
+
+clusters:
+  qumomf_sandbox:
+    routers:
+      - name: 'router_1'
+        uuid: 'router_1_uuid'
+        addr: '127.0.0.1:9301'
+
+    shards:
+      7432f072-c00b-4498-b1a6-6d9547a8a150:
         - name: 'qumomf_1_m'
-          addr: '127.0.0.1:9303'
-          user: 'qumomf'
-          password: 'qumomf'
-          priority: 42
           uuid: '294e7310-13f0-4690-b136-169599e87ba0'
+          addr: '127.0.0.1:9303'
+          priority: 42
           master: true
 
         - name: 'qumomf_1_s'
-          addr: '127.0.0.1:9304'
-          user: 'qumomf'
-          password: 'qumomf'
-          priority: 4
           uuid: 'cd1095d1-1e73-4ceb-8e2f-6ebdc7838cb1'
+          addr: '127.0.0.1:9304'
+          priority: 4
           master: false
 
-    5065fb5f-5f40-498e-af79-43887ba3d1ec:
+      5065fb5f-5f40-498e-af79-43887ba3d1ec:
         - name: 'qumomf_2_m'
-          addr: '127.0.0.1:9305'
-          user: 'qumomf'
-          password: 'qumomf'
-          priority: 42
           uuid: 'f3ef657e-eb9a-4730-b420-7ea78d52797d'
+          addr: '127.0.0.1:9305'
+          priority: 42
           master: true
 
         - name: 'qumomf_2_s'
-          addr: '127.0.0.1:9306'
-          user: 'qumomf'
-          password: 'qumomf'
-          priority: 4
           uuid: '7d64dd00-161e-4c99-8b3c-d3c4635e18d2'
+          addr: '127.0.0.1:9306'
+          priority: 4
           master: false
-
-routers:
-    - name: 'router_1'
-      addr: '127.0.0.1:9301'
-      user: 'qumomf'
-      password: 'qumomf'
-      priority: 0
-      uuid: 'some_router_uuid'

--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -1,0 +1,68 @@
+package coordinator
+
+import (
+	"errors"
+	"time"
+
+	"github.com/shmel1k/qumomf/internal/config"
+	"github.com/shmel1k/qumomf/pkg/quorum"
+	"github.com/shmel1k/qumomf/pkg/vshard"
+	"github.com/shmel1k/qumomf/pkg/vshard/orchestrator"
+)
+
+var (
+	ErrClusterAlreadyExist = errors.New("cluster with such name already registered")
+)
+
+type shutdownTask func()
+
+type Coordinator struct {
+	// clusters contains registered Tarantool clusters
+	// which Qumomf observes.
+	clusters map[string]vshard.Cluster
+
+	// shutdownQueue contains all shutdown tasks to be
+	// executed when coordinator is going to exit.
+	shutdownQueue []shutdownTask
+}
+
+func New() *Coordinator {
+	return &Coordinator{
+		clusters: make(map[string]vshard.Cluster),
+	}
+}
+
+func (c Coordinator) RegisterCluster(name string, cfg config.ClusterConfig) error {
+	if _, exist := c.clusters[name]; exist {
+		return ErrClusterAlreadyExist
+	}
+
+	cluster := vshard.NewCluster(cfg.Routers, cfg.Shards)
+	c.clusters[name] = cluster
+	c.addShutdownTask(cluster.Shutdown)
+
+	mon := orchestrator.NewMonitor(orchestrator.Config{
+		InstancePollPeriod: time.Second, // TODO: move to global config
+	}, cluster)
+	c.addShutdownTask(mon.Shutdown)
+
+	elector := quorum.NewLagQuorum() // TODO: move to cluster specific config
+	failover := orchestrator.NewSwapMasterFailover(cluster, elector)
+	c.addShutdownTask(failover.Shutdown)
+
+	analysisStream := mon.Serve()
+	failover.Serve(analysisStream)
+
+	return nil
+}
+
+func (c Coordinator) Shutdown() {
+	for i := len(c.shutdownQueue) - 1; i >= 0; i-- {
+		task := c.shutdownQueue[i]
+		task()
+	}
+}
+
+func (c Coordinator) addShutdownTask(task shutdownTask) {
+	c.shutdownQueue = append(c.shutdownQueue, task)
+}

--- a/pkg/vshard/orchestrator/config.go
+++ b/pkg/vshard/orchestrator/config.go
@@ -3,5 +3,5 @@ package orchestrator
 import "time"
 
 type Config struct {
-	CheckTimeout time.Duration
+	InstancePollPeriod time.Duration
 }

--- a/pkg/vshard/orchestrator/monitor.go
+++ b/pkg/vshard/orchestrator/monitor.go
@@ -89,7 +89,7 @@ func (m *storageMonitor) analyzeReplicas(ctx context.Context, set vshard.Replica
 }
 
 func (m *storageMonitor) serveReplicaSet(r vshard.ReplicaSet, stream AnalysisWriteStream) {
-	tick := time.NewTicker(m.config.CheckTimeout)
+	tick := time.NewTicker(m.config.InstancePollPeriod)
 	defer tick.Stop()
 
 	ctx := context.Background()


### PR DESCRIPTION
Refactored configuration structure to add multiple clusters. Added global config for tarantool credentials
which should be passed when user do not provide his own.

Added coordinator which responsible for registering clusters and gracefully shutdown them.