### PR TITLE
Update the configuration of cluster nodes by their priority during the failover

### DIFF
--- a/internal/coordinator/coordinator.go
+++ b/internal/coordinator/coordinator.go
@@ -56,7 +56,7 @@ func (c Coordinator) RegisterCluster(name string, cfg config.ClusterConfig, glob
 	c.addShutdownTask(mon.Shutdown)
 
 	elector := quorum.NewLagQuorum() // TODO: move to cluster specific config
-	failover := orchestrator.NewSwapMasterFailover(cluster, orchestrator.FailoverConfig{
+	failover := orchestrator.NewPromoteFailover(cluster, orchestrator.FailoverConfig{
 		Logger:                      clusterLogger,
 		Elector:                     elector,
 		ReplicaSetRecoveryBlockTime: globalCfg.Qumomf.ShardRecoveryBlockTime,

--- a/pkg/vshard/orchestrator/failover_test.go
+++ b/pkg/vshard/orchestrator/failover_test.go
@@ -48,14 +48,14 @@ func Test_swapMasterFailover_promoteFollowerToMaster(t *testing.T) {
 
 	elector := quorum.NewLagQuorum()
 
-	var fv *swapMasterFailover
+	var fv *promoteFailover
 	{
-		failover := NewSwapMasterFailover(c, FailoverConfig{
+		failover := NewPromoteFailover(c, FailoverConfig{
 			Logger:                      zerolog.Nop(),
 			Elector:                     elector,
 			ReplicaSetRecoveryBlockTime: 2 * time.Second,
 		})
-		fv = failover.(*swapMasterFailover)
+		fv = failover.(*promoteFailover)
 	}
 
 	stream := NewAnalysisStream()

--- a/pkg/vshard/orchestrator/instance_utils.go
+++ b/pkg/vshard/orchestrator/instance_utils.go
@@ -1,0 +1,40 @@
+package orchestrator
+
+import "github.com/shmel1k/qumomf/pkg/vshard"
+
+// InstanceFailoverSorter sorts instances by priority to update vshard configuration.
+type InstanceFailoverSorter struct {
+	instances []vshard.Instance
+}
+
+func NewInstanceFailoverSorter(instances []vshard.Instance) *InstanceFailoverSorter {
+	return &InstanceFailoverSorter{
+		instances: instances,
+	}
+}
+
+func (s *InstanceFailoverSorter) Len() int {
+	return len(s.instances)
+}
+
+func (s *InstanceFailoverSorter) Swap(i, j int) {
+	s.instances[i], s.instances[j] = s.instances[j], s.instances[i]
+}
+
+func (s *InstanceFailoverSorter) Less(i, j int) bool {
+	left, right := s.instances[i], s.instances[j]
+
+	// Prefer replicas which was polled successfully last time.
+	if left.LastCheckValid && !right.LastCheckValid {
+		return true
+	}
+	// Prefer instance which has unreachable master.
+	if left.HasAlert(vshard.AlertUnreachableMaster) && !right.HasAlert(vshard.AlertUnreachableMaster) {
+		return true
+	}
+	if right.HasAlert(vshard.AlertUnreachableMaster) && !left.HasAlert(vshard.AlertUnreachableMaster) {
+		return false
+	}
+	// Prefer most up to date replica.
+	return left.StorageInfo.Replication.Delay < right.StorageInfo.Replication.Delay
+}

--- a/pkg/vshard/orchestrator/instance_utils_test.go
+++ b/pkg/vshard/orchestrator/instance_utils_test.go
@@ -1,0 +1,93 @@
+package orchestrator
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/shmel1k/qumomf/pkg/vshard"
+)
+
+func TestInstanceFailoverSorter(t *testing.T) {
+	instances := []vshard.Instance{
+		{
+			UUID:           "replica_1",
+			LastCheckValid: false,
+			StorageInfo: vshard.StorageInfo{
+				Replication: vshard.Replication{
+					Status: "",
+					Delay:  0,
+				},
+				Alerts: nil,
+			},
+		},
+		{
+			UUID:           "replica_2",
+			LastCheckValid: true,
+			StorageInfo: vshard.StorageInfo{
+				Replication: vshard.Replication{
+					Status: vshard.StatusDisconnected,
+					Delay:  0.032492704689502716,
+				},
+				Alerts: []vshard.Alert{
+					{
+						Type:        vshard.AlertUnreachableMaster,
+						Description: "Master of replicaset is unreachable: disconnected",
+					},
+				},
+			},
+		},
+		{
+			UUID:           "replica_3",
+			LastCheckValid: true,
+			StorageInfo: vshard.StorageInfo{
+				Replication: vshard.Replication{
+					Status: vshard.StatusDisconnected,
+					Delay:  3.479430440813303,
+				},
+				Alerts: []vshard.Alert{
+					{
+						Type:        vshard.AlertUnreachableMaster,
+						Description: "Master of replicaset is unreachable: disconnected",
+					},
+				},
+			},
+		},
+		{
+			UUID:           "replica_4",
+			LastCheckValid: true,
+			StorageInfo: vshard.StorageInfo{
+				Replication: vshard.Replication{
+					Status: vshard.StatusFollow,
+					Delay:  0.079430440813303,
+				},
+				Alerts: nil,
+			},
+		},
+		{
+			UUID:           "replica_5",
+			LastCheckValid: true,
+			StorageInfo: vshard.StorageInfo{
+				Replication: vshard.Replication{
+					Status: vshard.StatusMaster,
+					Delay:  0,
+				},
+				Alerts: nil,
+			},
+		},
+	}
+
+	sort.Sort(NewInstanceFailoverSorter(instances))
+
+	expected := []vshard.InstanceUUID{
+		"replica_2", "replica_3", "replica_5", "replica_4", "replica_1",
+	}
+
+	got := make([]vshard.InstanceUUID, 0, len(instances))
+	for _, inst := range instances {
+		got = append(got, inst.UUID)
+	}
+
+	assert.Equal(t, expected, got)
+}


### PR DESCRIPTION
Previously qumomf updated the topology conf in random order just logging successful and failed attempts.

Now qumomf tries to update conf of the chosen candidate, then sorts all replicas by their current state before iterating over them. It should decrease the chance of inconsistent vshard topology.