### PR TITLE
Implemented recovery without predefined stored procedures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ run: build
 .PHONY: env_up
 env_up:
 	docker-compose -f example/docker-compose.yml up -d
-	sleep 1
+	sleep 2
 	docker-compose -f example/docker-compose.yml ps
 
 .PHONY: env_down

--- a/README.md
+++ b/README.md
@@ -17,32 +17,25 @@ clusters:
 
 You might override default connection settings for each cluster.
 
-Add Lua procedure on all storages or adapt it for your environment:
+```yaml
+clusters:
+  my_cluster:
+    connection:
+      user: 'tnt'
+      password: 'tnt'
+      connect_timeout: 10s
+      request_timeout: 10s
 
-```lua
-function qumomf_change_master(shard_uuid, old_master_uuid, new_master_uuid)
-    local replicas = cfg.sharding[shard_uuid].replicas
-    replicas[old_master_uuid].master = false
-    replicas[new_master_uuid].master = true
-    vshard.storage.cfg(cfg, os.getenv('STORAGE_UUID'))
-end
+    routers:
+      - name: 'my_cluster_router_1'
+        addr: 'localhost:3301'
+        uuid: 'my_cluster_router_1'
 ```
 
-On routers:
+For a sample vshard configuration, 
+see [qumomf example](/example) or [Tarantool documentation](https://www.tarantool.io/en/doc/1.10/reference/reference_rock/vshard/vshard_quick/#vshard-config-cluster-example).
 
-```lua
-function qumomf_change_master(shard_uuid, old_master_uuid, new_master_uuid)
-    local replicas = cfg.sharding[shard_uuid].replicas
-    replicas[old_master_uuid].master = false
-    replicas[new_master_uuid].master = true
-    vshard.router.cfg(cfg)
-end
-```
-
-`cfg` is a local variable contains the configuration of the replica sets. 
-For a sample configuration, see [qumomf example](/example) or [Tarantool documentation](https://www.tarantool.io/en/doc/1.10/reference/reference_rock/vshard/vshard_quick/#vshard-config-cluster-example).
-
-Start or restart qumomf and the orchestrator will discover all configured clusters.
+Start qumomf, and it will discover all defined clusters.
 
 ## Test
 

--- a/example/qumomf.yaml
+++ b/example/qumomf.yaml
@@ -9,7 +9,7 @@ qumomf:
 connection:
   user: 'qumomf'
   password: 'qumomf'
-  connect_timeout: '1s'
+  connect_timeout: '500ms'
   request_timeout: '1s'
 
 clusters:

--- a/example/router/init_router.lua
+++ b/example/router/init_router.lua
@@ -47,12 +47,5 @@ end)
 vshard.router.bootstrap()
 vshard.router.discovery_wakeup()
 
-function qumomf_change_master(shard_uuid, old_master_uuid, new_master_uuid)
-    local replicas = cfg.sharding[shard_uuid].replicas
-    replicas[old_master_uuid].master = false
-    replicas[new_master_uuid].master = true
-    vshard.router.cfg(cfg)
-end
-
 dofile('/etc/tarantool/instances.enabled/qumomf/router/router.lua')
 

--- a/example/storage/init_storage.lua
+++ b/example/storage/init_storage.lua
@@ -72,11 +72,4 @@ box.once("init", function()
     })
 end)
 
-function qumomf_change_master(shard_uuid, old_master_uuid, new_master_uuid)
-    local replicas = cfg.sharding[shard_uuid].replicas
-    replicas[old_master_uuid].master = false
-    replicas[new_master_uuid].master = true
-    vshard.storage.cfg(cfg, os.getenv('STORAGE_UUID'))
-end
-
 dofile('/etc/tarantool/instances.enabled/qumomf/storage/storage.lua')

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ const (
 	defaultReadOnly               = true
 	defaultUser                   = "guest"
 	defaultPassword               = "guest"
-	defaultConnectTimeout         = 1 * time.Second
+	defaultConnectTimeout         = 500 * time.Millisecond
 	defaultRequestTimeout         = 1 * time.Second
 	defaultClusterDiscoveryTime   = 5 * time.Second
 	defaultClusterRecoveryTime    = 1 * time.Second

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,14 +29,14 @@ func TestSetup_ValidPath(t *testing.T) {
 	assert.Equal(t, 60*time.Second, cfg.Qumomf.ClusterDiscoveryTime)
 	assert.Equal(t, 5*time.Second, cfg.Qumomf.ClusterRecoveryTime)
 
+	assert.Equal(t, 500*time.Millisecond, *cfg.Connection.ConnectTimeout)
 	assert.Equal(t, 1*time.Second, *cfg.Connection.RequestTimeout)
-	assert.Equal(t, 1*time.Second, *cfg.Connection.ConnectTimeout)
 
 	connOpts := cfg.Connection
 	require.NotNil(t, connOpts)
 	assert.Equal(t, "qumomf", *connOpts.User)
 	assert.Equal(t, "qumomf", *connOpts.Password)
-	assert.Equal(t, 1*time.Second, *connOpts.ConnectTimeout)
+	assert.Equal(t, 500*time.Millisecond, *connOpts.ConnectTimeout)
 	assert.Equal(t, 1*time.Second, *connOpts.RequestTimeout)
 
 	expected := map[string]ClusterConfig{
@@ -44,7 +44,7 @@ func TestSetup_ValidPath(t *testing.T) {
 			Connection: &ConnectConfig{
 				User:           newString("qumomf"),
 				Password:       newString("qumomf"),
-				ConnectTimeout: newDuration(1 * time.Second),
+				ConnectTimeout: newDuration(500 * time.Millisecond),
 				RequestTimeout: newDuration(1 * time.Second),
 			},
 			ReadOnly: newBool(false),

--- a/internal/config/testdata/qumomf-full.conf.yaml
+++ b/internal/config/testdata/qumomf-full.conf.yaml
@@ -9,7 +9,7 @@ qumomf:
 connection:
   user: 'qumomf'
   password: 'qumomf'
-  connect_timeout: '1s'
+  connect_timeout: '500ms'
   request_timeout: '1s'
 
 clusters:

--- a/pkg/vshard/cluster_test.go
+++ b/pkg/vshard/cluster_test.go
@@ -133,7 +133,7 @@ func TestCluster_Instance(t *testing.T) {
 	sets := []ReplicaSet{
 		{
 			UUID:       "set_1",
-			MasterUUID: "replica_1",
+			MasterUUID: "set_1_replica_1",
 			Instances: []Instance{
 				{
 					UUID: "set_1_replica_1",
@@ -148,7 +148,7 @@ func TestCluster_Instance(t *testing.T) {
 		},
 		{
 			UUID:       "set_2",
-			MasterUUID: "replica_2",
+			MasterUUID: "set_2_replica_2",
 			Instances: []Instance{
 				{
 					UUID: "set_2_replica_1",

--- a/pkg/vshard/parser_test.go
+++ b/pkg/vshard/parser_test.go
@@ -17,7 +17,6 @@ func TestParseRouterInfo(t *testing.T) {
 	conn := setupConnection("127.0.0.1:9301", ConnOptions{
 		User:           "qumomf",
 		Password:       "qumomf",
-		UUID:           "router_1_uuid",
 		ConnectTimeout: 1 * time.Second,
 		QueryTimeout:   1 * time.Second,
 	})
@@ -80,7 +79,6 @@ func TestParseReplication(t *testing.T) {
 	conn := setupConnection("127.0.0.1:9303", ConnOptions{
 		User:           "qumomf",
 		Password:       "qumomf",
-		UUID:           "294e7310-13f0-4690-b136-169599e87ba0",
 		ConnectTimeout: 1 * time.Second,
 		QueryTimeout:   1 * time.Second,
 	})
@@ -124,7 +122,6 @@ func TestParseInstanceInfo(t *testing.T) {
 	conn := setupConnection("127.0.0.1:9304", ConnOptions{
 		User:           "qumomf",
 		Password:       "qumomf",
-		UUID:           "294e7310-13f0-4690-b136-169599e87ba0",
 		ConnectTimeout: 1 * time.Second,
 		QueryTimeout:   1 * time.Second,
 	})

--- a/pkg/vshard/snapshot.go
+++ b/pkg/vshard/snapshot.go
@@ -1,0 +1,38 @@
+package vshard
+
+import "encoding/json"
+
+// Snapshot is a copy of the cluster topology in given time.
+type Snapshot struct {
+	Created     int64        `json:"created"`
+	Routers     []Router     `json:"routers"`
+	ReplicaSets []ReplicaSet `json:"replica_sets"`
+}
+
+func (s Snapshot) String() string {
+	j, _ := json.Marshal(s)
+	return string(j)
+}
+
+func (s *Snapshot) Copy() Snapshot {
+	dst := Snapshot{
+		Created:     s.Created,
+		Routers:     make([]Router, len(s.Routers)),
+		ReplicaSets: make([]ReplicaSet, len(s.ReplicaSets)),
+	}
+
+	copy(dst.Routers, s.Routers)
+	copy(dst.ReplicaSets, s.ReplicaSets)
+
+	return dst
+}
+
+func (s *Snapshot) TopologyOf(uuid ReplicaSetUUID) ([]Instance, error) {
+	for _, set := range s.ReplicaSets {
+		if set.UUID == uuid {
+			return set.Instances, nil
+		}
+	}
+
+	return []Instance{}, ErrReplicaSetNotFound
+}

--- a/pkg/vshard/tarantool_test.go
+++ b/pkg/vshard/tarantool_test.go
@@ -95,7 +95,6 @@ func TestPool_Get(t *testing.T) {
 	connOpts := ConnOptions{
 		User:     "qumomf",
 		Password: "qumomf",
-		UUID:     "uuid",
 	}
 	p := NewConnPool(connOpts, nil)
 	uri := "tarantool.repl:3301"
@@ -106,7 +105,7 @@ func TestPool_Get(t *testing.T) {
 	wg.Add(n)
 	for i := 0; i < n; i++ {
 		go func() {
-			ch <- p.Get(uri, "uuid")
+			ch <- p.Get(uri)
 			wg.Done()
 		}()
 	}
@@ -128,7 +127,6 @@ func BenchmarkPool_Get(b *testing.B) {
 	connOpts := ConnOptions{
 		User:     "qumomf",
 		Password: "qumomf",
-		UUID:     "uuid",
 	}
 	p := NewConnPool(connOpts, nil)
 
@@ -144,7 +142,7 @@ func BenchmarkPool_Get(b *testing.B) {
 		ub.WriteString(":3301")
 		uri = ub.String()
 
-		conn = p.Get(uri, "uuid")
+		conn = p.Get(uri)
 		conn.Close()
 	}
 }


### PR DESCRIPTION
Previously to use a failover user should add global procedures to each cluster node manually. It led to errors and inconsistent cluster topology when procedures were not found.

To make qumomf fully independent from cluster I implemented a recovery process which reads current topology configuration and changes it on the fly using Lua expression template.