### PR TITLE
Added new analysis type: MasterMasterReplication

### DIFF
--- a/internal/vshard/orchestrator/analysis.go
+++ b/internal/vshard/orchestrator/analysis.go
@@ -23,6 +23,7 @@ const (
 	DeadMasterWithoutFollowers       ReplicaSetState = "DeadMasterWithoutFollowers"
 	AllMasterFollowersNotReplicating ReplicaSetState = "AllMasterFollowersNotReplicating"
 	NetworkProblems                  ReplicaSetState = "NetworkProblems"
+	MasterMasterReplication          ReplicaSetState = "MasterMasterReplication"
 	InconsistentVShardConfiguration  ReplicaSetState = "InconsistentVShardConfiguration"
 )
 

--- a/internal/vshard/orchestrator/failover_test.go
+++ b/internal/vshard/orchestrator/failover_test.go
@@ -151,7 +151,7 @@ func (s *failoverTestSuite) Test_failover_promoteFollowerToMaster() {
 	}
 }
 
-func (s *failoverTestSuite) Test_failover_wishEventualConsistency() {
+func (s *failoverTestSuite) Test_failover_migrateMMToMSTopology() {
 	t := s.T()
 
 	if testing.Short() {
@@ -194,7 +194,7 @@ func (s *failoverTestSuite) Test_failover_wishEventualConsistency() {
 				CountWorkingReplicas:        1,
 				CountReplicatingReplicas:    1,
 				CountInconsistentVShardConf: 1,
-				State:                       InconsistentVShardConfiguration,
+				State:                       MasterMasterReplication,
 			}
 			stream <- analysis
 

--- a/internal/vshard/orchestrator/monitor_test.go
+++ b/internal/vshard/orchestrator/monitor_test.go
@@ -180,6 +180,25 @@ func Test_storageMonitor_analyze(t *testing.T) {
 			},
 		},
 		{
+			name: "MasterMasterReplication",
+			set: vshard.ReplicaSet{
+				UUID:       "set_1",
+				MasterUUID: "replica_1",
+				Instances: []vshard.Instance{
+					mockInstance(1, true, vshard.StatusMaster),
+					mockInvalidVShardConf(mockInstance(2, true, vshard.StatusMaster)),
+					mockInstance(3, true, vshard.StatusFollow),
+				},
+			},
+			want: &ReplicationAnalysis{
+				CountReplicas:               2,
+				CountWorkingReplicas:        2,
+				CountReplicatingReplicas:    2,
+				CountInconsistentVShardConf: 1,
+				State:                       MasterMasterReplication,
+			},
+		},
+		{
 			name: "InconsistentVShardConfiguration",
 			set: vshard.ReplicaSet{
 				UUID:       "set_1",

--- a/internal/vshard/parser_test.go
+++ b/internal/vshard/parser_test.go
@@ -143,7 +143,7 @@ func TestParseInstanceInfo(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.True(t, data.Readonly)
-	assert.Equal(t, uint64(1010165886), data.VShardFingerprint)
+	assert.Equal(t, uint64(251215738), data.VShardFingerprint)
 
 	storage := &data.StorageInfo
 	assert.Equal(t, HealthCodeGreen, storage.Status)


### PR DESCRIPTION
Previously qumomf calculated hash of the vshard configuration and compared
it for each replica and leader in the set. This calculations was based on json
encoding which led to false failovers in case when replica had another order
of the fields in the configuration.

Another problem was that qumomf do not know how to build a full vshard configuration
to end up to a consistent configuration in the replica set.

To eliminate this problems I added a new analysis type MasterMasterReplication which
qumomf can fix applying follower role to all masters except the leader.

Also I changed the hash calculation algorithm: now it deep sorts vshard config of the set
before calculating.